### PR TITLE
Extend test for RemoveBlankEntries method 

### DIFF
--- a/CsharpExtrasTest/Extensions/ArrayExtensionTest.cs
+++ b/CsharpExtrasTest/Extensions/ArrayExtensionTest.cs
@@ -169,28 +169,29 @@ namespace CustomExtensions
         //non-mvp: Add test for getting subarray from out of bounds on only one side. 
         // For example: -1 to the middle of the source array
 
-        private static IEnumerable<(string[] Result, int ExpectedBlanks)> TupleArrayProviderForRemoveBlanksTesting()
+        private static IEnumerable<(string[] Result, string[] ExpectedBlanks)> TupleArrayProviderForRemoveBlanksTesting()
         {
-            return new List<(string[] Result, int ExpectedBlanks)>
+            return new List<(string[] input, string[] expected)>
             {
-                (Result: new string[] {"a1", "", "a3", "a4", "  "}, ExpectedBlanks: 3),
-                (Result: new string[] { }, ExpectedBlanks: 0),
-                (Result: new string[] {"a1"}, ExpectedBlanks: 1),
-                (Result: new string[] {""}, ExpectedBlanks: 0),
-                (Result: new string[] {"  ", "a2"}, ExpectedBlanks: 1),
+                (input: new string[] {"a1", "", "a3", "a4", "  "}, expected: new string[] {"a1", "a3", "a4"}),
+                (input: new string[] { }, expected: new string[] {}),
+                (input: new string[] {"a1"}, expected: new string[] {"a1"}),
+                (input: new string[] {""}, expected: new string[] {}),
+                (input: new string[] {"  ", "a2"}, expected: new string[] {"a2"}),
             };
         }
 
         [Test]
         [Category("Unit")]
         [TestCaseSource("TupleArrayProviderForRemoveBlanksTesting")]
-        public void TestGivenStringArrayWhenRemoveBlankEntriesCalledThenAllBlankEntriesAreRemoved((string[] Result, int ExpectedBlanks) arr)
+        public void TestGivenStringArrayWhenRemoveBlankEntriesCalledThenAllBlankEntriesAreRemoved((string[] input, string[] expected) arr)
         {
-            Assert.NotNull(arr.Result, "GIVEN: String array should not be null");
+            Assert.NotNull(arr.input, "GIVEN: String array should not be null");
 
-            string[] cleaned = arr.Result.RemoveBlankEntries();
+            string[] cleaned = arr.input.RemoveBlankEntries();
 
-            Assert.AreEqual(arr.ExpectedBlanks, cleaned.Length, "Expected all blank entries to be removed");
+            Assert.AreEqual(arr.expected.Length, cleaned.Length, "Expected all blank entries to be removed");
+            Assert.AreEqual(arr.expected,cleaned);
             Assert.AreEqual(0, cleaned.Count(s => string.IsNullOrWhiteSpace(s)),
                 "No blank values should exist in the cleaned array");
         }

--- a/CsharpExtrasTest/Extensions/ArrayExtensionTest.cs
+++ b/CsharpExtrasTest/Extensions/ArrayExtensionTest.cs
@@ -189,9 +189,8 @@ namespace CustomExtensions
             Assert.NotNull(tuple.input, "GIVEN: String array should not be null");
 
             string[] cleaned = tuple.input.RemoveBlankEntries();
-
-            Assert.AreEqual(tuple.expected.Length, cleaned.Length, "Expected all blank entries to be removed");
-            Assert.AreEqual(tuple.expected,cleaned);
+            
+            Assert.AreEqual(tuple.expected,cleaned, "Array should be equal to expected array");
             Assert.AreEqual(0, cleaned.Count(s => string.IsNullOrWhiteSpace(s)),
                 "No blank values should exist in the cleaned array");
         }

--- a/CsharpExtrasTest/Extensions/ArrayExtensionTest.cs
+++ b/CsharpExtrasTest/Extensions/ArrayExtensionTest.cs
@@ -184,14 +184,14 @@ namespace CustomExtensions
         [Test]
         [Category("Unit")]
         [TestCaseSource("TupleArrayProviderForRemoveBlanksTesting")]
-        public void TestGivenStringArrayWhenRemoveBlankEntriesCalledThenAllBlankEntriesAreRemoved((string[] input, string[] expected) arr)
+        public void TestGivenStringArrayWhenRemoveBlankEntriesCalledThenAllBlankEntriesAreRemoved((string[] input, string[] expected) tuple)
         {
-            Assert.NotNull(arr.input, "GIVEN: String array should not be null");
+            Assert.NotNull(tuple.input, "GIVEN: String array should not be null");
 
-            string[] cleaned = arr.input.RemoveBlankEntries();
+            string[] cleaned = tuple.input.RemoveBlankEntries();
 
-            Assert.AreEqual(arr.expected.Length, cleaned.Length, "Expected all blank entries to be removed");
-            Assert.AreEqual(arr.expected,cleaned);
+            Assert.AreEqual(tuple.expected.Length, cleaned.Length, "Expected all blank entries to be removed");
+            Assert.AreEqual(tuple.expected,cleaned);
             Assert.AreEqual(0, cleaned.Count(s => string.IsNullOrWhiteSpace(s)),
                 "No blank values should exist in the cleaned array");
         }

--- a/CsharpExtrasTest/Extensions/ArrayExtensionTest.cs
+++ b/CsharpExtrasTest/Extensions/ArrayExtensionTest.cs
@@ -191,9 +191,6 @@ namespace CustomExtensions
         {
             Assert.NotNull(arr.Result, "GIVEN: String array should not be null");
 
-            int rawCount = arr.Result.Length;
-            int nonBlankCount = arr.Result.Count(s => !string.IsNullOrWhiteSpace(s));
-
             string[] cleaned = arr.Result.RemoveBlankEntries();
 
             Assert.AreEqual(arr.ExpectedBlanks, cleaned.Length, "Expected all blank entries to be removed");

--- a/CsharpExtrasTest/Extensions/ArrayExtensionTest.cs
+++ b/CsharpExtrasTest/Extensions/ArrayExtensionTest.cs
@@ -169,9 +169,6 @@ namespace CustomExtensions
         //non-mvp: Add test for getting subarray from out of bounds on only one side. 
         // For example: -1 to the middle of the source array
 
-        //non-mvp: Consider changing test to take a tupple of input array and number of expected blanks
-        // This will probably be a better test since the test uses the same code as the implementation
-
         private static IEnumerable<(string[] Result, int ExpectedBlanks)> TupleArrayProviderForRemoveBlanksTesting()
         {
             return new List<(string[] Result, int ExpectedBlanks)>

--- a/CsharpExtrasTest/Extensions/ArrayExtensionTest.cs
+++ b/CsharpExtrasTest/Extensions/ArrayExtensionTest.cs
@@ -172,30 +172,31 @@ namespace CustomExtensions
         //non-mvp: Consider changing test to take a tupple of input array and number of expected blanks
         // This will probably be a better test since the test uses the same code as the implementation
 
-        private static IEnumerable<string[]> StringArrayProviderForRemoveBlanksTesting()
+        private static IEnumerable<(string[] Result, int ExpectedBlanks)> TupleArrayProviderForRemoveBlanksTesting()
         {
-            return new List<string[]> {
-                new string[] { "a1", "", "a3", "a4", "  " },
-                new string[] {  },
-                new string[] { "a1" },
-                new string[] { "" },
-                new string[] { "  ", "a2" },
+            return new List<(string[] Result, int ExpectedBlanks)>
+            {
+                (Result: new string[] {"a1", "", "a3", "a4", "  "}, ExpectedBlanks: 3),
+                (Result: new string[] { }, ExpectedBlanks: 0),
+                (Result: new string[] {"a1"}, ExpectedBlanks: 1),
+                (Result: new string[] {""}, ExpectedBlanks: 0),
+                (Result: new string[] {"  ", "a2"}, ExpectedBlanks: 1),
             };
         }
 
         [Test]
         [Category("Unit")]
-        [TestCaseSource("StringArrayProviderForRemoveBlanksTesting")]
-        public void TestGivenStringArrayWhenRemoveBlankEntriesCalledThenAllBlankEntriesAreRemoved(string[] arr)
+        [TestCaseSource("TupleArrayProviderForRemoveBlanksTesting")]
+        public void TestGivenStringArrayWhenRemoveBlankEntriesCalledThenAllBlankEntriesAreRemoved((string[] Result, int ExpectedBlanks) arr)
         {
-            Assert.NotNull(arr, "GIVEN: String array should not be null");
+            Assert.NotNull(arr.Result, "GIVEN: String array should not be null");
 
-            int rawCount = arr.Length;
-            int nonBlankCount = arr.Count(s => !string.IsNullOrWhiteSpace(s));
+            int rawCount = arr.Result.Length;
+            int nonBlankCount = arr.Result.Count(s => !string.IsNullOrWhiteSpace(s));
 
-            string[] cleaned = arr.RemoveBlankEntries();
+            string[] cleaned = arr.Result.RemoveBlankEntries();
 
-            Assert.AreEqual(nonBlankCount, cleaned.Length, "Expected all blank entries to be removed");
+            Assert.AreEqual(arr.ExpectedBlanks, cleaned.Length, "Expected all blank entries to be removed");
             Assert.AreEqual(0, cleaned.Count(s => string.IsNullOrWhiteSpace(s)),
                 "No blank values should exist in the cleaned array");
         }


### PR DESCRIPTION
The `RemoveBlankEntries ` method now receives a tuple with the given input and the expected output array.

closes #24 
