### PR TITLE
Move coding conventions to wiki

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,4 +40,4 @@
 
 ## C# Coding Conventions
 
-You can find the latest coding conventions in the [wiki](https://github.com/ColmBhandal/CsharpExtras/wiki/Coding-Conventions).
+Code contributions should adhere to the coding conventions defined in the project [wiki](https://github.com/ColmBhandal/CsharpExtras/wiki/Coding-Conventions). We recommend you read them before you start working on something to reduce the chance of your pull request requiring changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,12 +40,4 @@
 
 ## C# Coding Conventions
 
-We typically follow these conventions when coding in most cases. We may request changes to your pull request based on the below. Please note that this doesn't always mean your code is "wrong", but it may be inconsistent relative to the conventions we've adopted. Where possible, we'll explain why we used certain conventions.
-
-| Convenrtion | Explanation |
-|---|---|
-| Use Explicit Types (not `var`) | We always prefer explicit types vs `var`. We feel the code is easier to read when the type is right there. |
-| Use Interface Types | Unless there's good reason to do so, avoid using raw classes. Use interfaces instead. This makes the code easily separable by the interface separation principle. So if you have a class `A` and a class `B` which uses `A`, rather than reference `A` directly from `B`, the recommendation is to create an interface `IA`, exposing only the public methods of `A` and then make `B` depend on `IA`.|
-| Variable Naming | As far as possible, variables should be named so that the meaning of the variable can be inferred from the variable. name. You can always start coding with variables like `i` and `j` and then when it's time to commit your code, you can use your IDE to rename the variables to something more descriptive e.g. `rowIndex` and `columnIndex`.|
-
-...More conventions will follow. Please be patient with us as we convert our coding experience to text...
+You can find the latest coding conventions in the [wiki](https://github.com/ColmBhandal/CsharpExtras/wiki/Coding-Conventions).


### PR DESCRIPTION
## Description

Remove the coding conventions section from the Contributing file and move them to the project wiki.
