### PR TITLE
Added the validated base type, numeric subtypes and tests

### DIFF
--- a/CsharpExtras/ValidatedType/Numeric/Integer/NonnegativeInteger.cs
+++ b/CsharpExtras/ValidatedType/Numeric/Integer/NonnegativeInteger.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CsharpExtras.ValidatedType.Numeric.Integer
+{
+    public class NonnegativeInteger : Validated<int>
+    {
+        public NonnegativeInteger(int value) : base(value)
+        {
+        }
+
+        protected override string ValidityConditionTextDescription => "Integer must be greater than or equal to zero.";
+
+        protected override bool IsValid(int t) => t >= 0;
+
+        public static explicit operator NonnegativeInteger(int value) => new NonnegativeInteger(value);
+    }
+}

--- a/CsharpExtras/ValidatedType/Numeric/Integer/PositiveInteger.cs
+++ b/CsharpExtras/ValidatedType/Numeric/Integer/PositiveInteger.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CsharpExtras.ValidatedType.Numeric.Integer
+{
+    public class PositiveInteger : Validated<int>
+    {
+        public PositiveInteger(int value) : base(value)
+        {
+        }
+
+        protected override string ValidityConditionTextDescription => "Integer must be greater than zero.";
+
+        protected override bool IsValid(int t) => t > 0;
+
+        public static explicit operator PositiveInteger(int value) => new PositiveInteger(value);
+    }
+}

--- a/CsharpExtras/ValidatedType/Validated.cs
+++ b/CsharpExtras/ValidatedType/Validated.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CsharpExtras.ValidatedType
+{
+    public abstract class Validated<TVal>
+    {
+        TVal Value;
+        protected Validated(TVal value)
+        {
+            if (IsValid(value))
+            {
+                Value = value;
+            }
+            else
+            {
+                string valueAsString = value?.ToString() ?? "NULL";
+                string message = string.Format("The value {0} is invalid. {1}",
+                    valueAsString, ValidityConditionTextDescription);
+                throw new ArgumentException(message);
+            }
+        }
+
+        public static implicit operator TVal(Validated<TVal> validated) => validated.Value;
+
+        protected abstract bool IsValid(TVal t);
+        protected abstract string ValidityConditionTextDescription { get; }
+
+    }
+}

--- a/CsharpExtras/ValidatedType/Validated.cs
+++ b/CsharpExtras/ValidatedType/Validated.cs
@@ -6,7 +6,7 @@ namespace CsharpExtras.ValidatedType
 {
     public abstract class Validated<TVal>
     {
-        TVal Value;
+        private readonly TVal Value;
         protected Validated(TVal value)
         {
             if (IsValid(value))

--- a/CsharpExtrasTest/ValidatedType/Numeric/NumericValidatedTest.cs
+++ b/CsharpExtrasTest/ValidatedType/Numeric/NumericValidatedTest.cs
@@ -1,0 +1,53 @@
+﻿using CsharpExtras.ValidatedType.Numeric.Integer;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CsharpExtrasTest.ValidatedType.Numeric
+{
+    [TestFixture]
+    [Category("Unit")]
+    class NumericValidatedTest
+    {
+        [Test, TestCase(-7423), TestCase(-1), TestCase(0)]
+        public void Given_NonPositiveInteger_When_AssignToPositiveInteger_Then_ExceptionThrown(int value)
+        {
+            PositiveInteger posInt;
+            Assert.Catch(() => posInt = (PositiveInteger) value);
+        }
+
+        [Test, TestCase(7423), TestCase(1)]
+        public void Given_RawPositiveInteger_When_AssignToPositiveInteger_Then_ValueMatchesInput
+            (int value)
+        {
+            //Assemble
+            PositiveInteger posInt;
+            //Act
+            posInt = (PositiveInteger)value;
+            //Assert
+            int actual = posInt;
+            Assert.AreEqual(value, actual);
+        }
+
+        [Test, TestCase(-228), TestCase(-1)]
+        public void Given_NonNonnegativeInteger_When_AssignToNonnegativeInteger_Then_ExceptionThrown(int value)
+        {
+            NonnegativeInteger posInt;
+            Assert.Catch(() => posInt = (NonnegativeInteger)value);
+        }
+
+        [Test, TestCase(241), TestCase(1), TestCase(0)]
+        public void Given_RawNonnegativeInteger_When_AssignToNonnegativeInteger_Then_ValueMatchesInput
+            (int value)
+        {
+            //Assemble
+            NonnegativeInteger posInt;
+            //Act
+            posInt = (NonnegativeInteger)value;
+            //Assert
+            int actual = posInt;
+            Assert.AreEqual(value, actual);
+        }
+    }
+}


### PR DESCRIPTION
## Description

The validated base type is public and abstract so can be extended in external code
The nonnegative and positive integer sutypes validate the integer accordingly
Tests for invalid and valid assignments are given
Note: the valid test cases make use of the implicit conversion operator defined on the abstract base type