### PR TITLE
Treat all warnings as errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [BREAKING] Move the ArrayOrientation enum to a new namespace (#9)
 - [BREAKING] Rename main namespace from `CustomExtensions` to `Extensions` (#9)
+- [BREAKING] The `TryGetSingleton` extension is now only available for collections with elements of type `class` (#49)
 - 2D one-based arrays are now enumerable (#45)
 - Multi-value maps are now comparable using set-equality as the default equals method (#48)
 - Project now treats all warnings as errors, minor changes made to fix all errors (#49)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [BREAKING] Rename main namespace from `CustomExtensions` to `Extensions` (#9)
 - 2D one-based arrays are now enumerable (#45)
 - Multi-value maps are now comparable using set-equality as the default equals method (#48)
+- Project now treats all warnings as errors, minor changes made to fix all errors (#49)
 
 ### Added
 - Support for writing a 1D one-based array to a 2D one-based array (#9)

--- a/CsharpExtras/CsharpExtras.csproj
+++ b/CsharpExtras/CsharpExtras.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <LangVersion>8.0</LangVersion>
-    <WarningsAsErrors></WarningsAsErrors>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>

--- a/CsharpExtras/CsharpExtras.csproj
+++ b/CsharpExtras/CsharpExtras.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	<Nullable>enable</Nullable>
-	<LangVersion>8.0</LangVersion>
-	<WarningsAsErrors>CS8600;CS8602;CS8603;CS8618</WarningsAsErrors>
-	<TargetFramework>netstandard2.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>8.0</LangVersion>
+    <WarningsAsErrors></WarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>1.0.0.9</Version>
+    <Version>0.0.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CsharpExtras/Dictionary/BijectionDictionaryImpl.cs
+++ b/CsharpExtras/Dictionary/BijectionDictionaryImpl.cs
@@ -9,8 +9,8 @@ namespace CsharpExtras.Dictionary
 {
     public class BijectionDictionaryImpl<TKey, TValue> : IBijectionDictionary<TKey, TValue>
     {
-        private IDictionary<TKey, TValue> _delegate = new Dictionary<TKey, TValue>();
-        private IDictionary<TValue, TKey> _reverseDelegate = new Dictionary<TValue, TKey>();
+        private readonly IDictionary<TKey, TValue> _delegate = new Dictionary<TKey, TValue>();
+        private readonly IDictionary<TValue, TKey> _reverseDelegate = new Dictionary<TValue, TKey>();
 
         private IBijectionDictionary<TValue, TKey>? _reverse;
         public IBijectionDictionary<TValue, TKey> Reverse => _reverse ?? (_reverse = new BijectionDictionaryImpl<TValue, TKey>(_reverseDelegate, this));

--- a/CsharpExtras/Dictionary/IMultiValueMap.cs
+++ b/CsharpExtras/Dictionary/IMultiValueMap.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CsharpExtras.Dictionary
+{
+    public interface IMultiValueMap<TKey, TVal> : IDictionary<TKey, ISet<TVal>>
+    {
+        void Add(TKey key, TVal value);
+
+        bool AnyValues();
+
+        /// <summary>
+        /// Generates a new multivalue map whose sets are the image of applying the transformer to this map's sets.
+        /// </summary>
+        /// <typeparam name="TOther">The return type of the transformer function.</typeparam>
+        /// <param name="transformer">A function which transforms each value to some other value.</param>
+        /// <returns>A new map, with the same keyset as this, whose values are sets resulting from applying the transformer
+        /// to all elements of the corresponding set in this map and then aggregating the mapped elements to a set.
+        /// Note: the sets in the resuling map may be smaller than those in the original map, if the transformer function maps many-to-one.</returns>
+        IMultiValueMap<TKey, TOther> TransformValues<TOther>(Func<TVal, TOther> transformer);
+    }
+}

--- a/CsharpExtras/Dictionary/MultiValueMapImpl.cs
+++ b/CsharpExtras/Dictionary/MultiValueMapImpl.cs
@@ -158,8 +158,20 @@ namespace CsharpExtras.Dictionary
         public override int GetHashCode()
         {
             int hashCode = -170788016;
-            hashCode = hashCode * -1521134295 + EqualityComparer<ICollection<TKey>>.Default.GetHashCode(Keys);
-            hashCode = hashCode * -1521134295 + EqualityComparer<ICollection<ISet<TVal>>>.Default.GetHashCode(Values);
+            foreach (KeyValuePair<TKey, ISet<TVal>> pair in _setValuedMap)
+            {
+                if (pair.Key != null)
+                {
+                    hashCode ^= pair.Key.GetHashCode();
+                }
+                foreach (TVal value in pair.Value)
+                {
+                    if (value != null)
+                    {
+                        hashCode ^= value.GetHashCode();
+                    }
+                }
+            }
             return hashCode;
         }
     }

--- a/CsharpExtras/Dictionary/MultiValueMapImpl.cs
+++ b/CsharpExtras/Dictionary/MultiValueMapImpl.cs
@@ -7,24 +7,10 @@ using System.Threading.Tasks;
 
 namespace CsharpExtras.Dictionary
 {
-    public interface IMultiValueMap<TKey, TVal> : IDictionary<TKey, ISet<TVal>>
-    {
-        void Add(TKey key, TVal value);
-        bool AnyValues();
-        /// <summary>
-        /// Generates a new multivalue map whose sets are the image of applying the transformer to this map's sets.
-        /// </summary>
-        /// <typeparam name="TOther">The return type of the transformer function.</typeparam>
-        /// <param name="transformer">A function which transforms each value to some other value.</param>
-        /// <returns>A new map, with the same keyset as this, whose values are sets resulting from applying the transformer
-        /// to all elements of the corresponding set in this map and then aggregating the mapped elements to a set.
-        /// Note: the sets in the resuling map may be smaller than those in the original map, if the transformer function maps many-to-one.</returns>
-        IMultiValueMap<TKey, TOther> TransformValues<TOther>(Func<TVal, TOther> transformer);
-    }
 
     class MultiValueMapImpl<TKey, TVal> : IMultiValueMap<TKey, TVal>, IDictionary<TKey, ISet<TVal>>
     {
-        private IDictionary<TKey, ISet<TVal>> _setValuedMap = new Dictionary<TKey, ISet<TVal>>();
+        private readonly IDictionary<TKey, ISet<TVal>> _setValuedMap = new Dictionary<TKey, ISet<TVal>>();
 
         public ISet<TVal> this[TKey key] { get => _setValuedMap[key]; set => _setValuedMap[key] = value; }
 
@@ -167,6 +153,14 @@ namespace CsharpExtras.Dictionary
                 }
             }
             return true;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -170788016;
+            hashCode = hashCode * -1521134295 + EqualityComparer<ICollection<TKey>>.Default.GetHashCode(Keys);
+            hashCode = hashCode * -1521134295 + EqualityComparer<ICollection<ISet<TVal>>>.Default.GetHashCode(Values);
+            return hashCode;
         }
     }
 }

--- a/CsharpExtras/Enumerable/OneBased/OneBasedArray2D.cs
+++ b/CsharpExtras/Enumerable/OneBased/OneBasedArray2D.cs
@@ -1,5 +1,4 @@
 ﻿using CsharpExtras.Extensions;
-using CsharpExtras.Extensions;
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/CsharpExtras/Extensions/ArrayExtension.cs
+++ b/CsharpExtras/Extensions/ArrayExtension.cs
@@ -108,8 +108,7 @@ namespace CsharpExtras.Extensions
                 }
                 else
                 {
-                    IList<int> lst = new List<int>();
-                    lst.Add(index);
+                    IList<int> lst = new List<int> { index };
                     inverseMap.Add(value, lst);
                 }
             }

--- a/CsharpExtras/Extensions/CollectionExtension.cs
+++ b/CsharpExtras/Extensions/CollectionExtension.cs
@@ -8,7 +8,7 @@ namespace CsharpExtras.Extensions
 {
     public static class CollectionExtension
     {
-        public static bool TryGetSingleton<TValueType>(this ICollection<TValueType> collection, out TValueType? singleton) where TValueType : class
+        public static bool TryGetSingleton<TValue>(this ICollection<TValue> collection, out TValue? singleton) where TValue : class
         {
             singleton = default;
             if (collection.Count == 0)
@@ -23,7 +23,7 @@ namespace CsharpExtras.Extensions
             return false;
         }
 
-        public static TValueType GetSingletonOrFail<TValueType>(this ICollection<TValueType> collection)
+        public static TValue GetSingletonOrFail<TValue>(this ICollection<TValue> collection)
         {
             if (collection.Count == 0)
             {

--- a/CsharpExtras/Extensions/CollectionExtension.cs
+++ b/CsharpExtras/Extensions/CollectionExtension.cs
@@ -8,7 +8,7 @@ namespace CsharpExtras.Extensions
 {
     public static class CollectionExtension
     {
-        public static bool TryGetSingleton<TValueType>(this ICollection<TValueType> collection, out TValueType singleton)
+        public static bool TryGetSingleton<TValueType>(this ICollection<TValueType> collection, out TValueType? singleton) where TValueType : class
         {
             singleton = default;
             if (collection.Count == 0)

--- a/CsharpExtras/Extensions/StringExtension.cs
+++ b/CsharpExtras/Extensions/StringExtension.cs
@@ -83,8 +83,7 @@ namespace CsharpExtras.Extensions
         /// <returns>Empty string if conversion fails, or a date value in ISO format otherwise</returns>
         public static string TryConvertOadDateStringToFormattedDate(this string oadDate)
         {
-            double parsedDate;
-            if (double.TryParse(oadDate, out parsedDate))
+            if (double.TryParse(oadDate, out double parsedDate))
             {
                 DateTime conv = DateTime.FromOADate(parsedDate);
                 return conv.ToString("yyyy-MM-dd");

--- a/CsharpExtrasTest/Dictionary/MultiValueMapTest.cs
+++ b/CsharpExtrasTest/Dictionary/MultiValueMapTest.cs
@@ -111,10 +111,10 @@ namespace CsharpExtrasTest.Dictionary
             map1.Add(2, "d");
             map1.Add(2, "e");
 
-            map2.Add(2, "d");
+            map2.Add(2, "e");
             map2.Add(1, "c");
             map2.Add(1, "a");
-            map2.Add(2, "e");
+            map2.Add(2, "d");
             map2.Add(1, "b");
 
             //Assert

--- a/CsharpExtrasTest/Dictionary/MultiValueMapTest.cs
+++ b/CsharpExtrasTest/Dictionary/MultiValueMapTest.cs
@@ -95,5 +95,51 @@ namespace CsharpExtrasTest.Dictionary
             Assert.IsTrue(new HashSet<int>(new int[] {3}).SetEquals(transformedMap[2]));
             Assert.IsTrue(new HashSet<int>(new int[] {5}).SetEquals(transformedMap[3]));
         }
+
+        [Test]
+        [Category("Unit")]
+        public void Given_TwoMaps_When_TheSameDataIsAddedInDifferentOrders_Then_MapHashCodesMatch()
+        {
+            //Assemble
+            IMultiValueMap<int, string> map1 = new MultiValueMapImpl<int, string>();
+            IMultiValueMap<int, string> map2 = new MultiValueMapImpl<int, string>();
+
+            //Act
+            map1.Add(1, "a");
+            map1.Add(1, "b");
+            map1.Add(1, "c");
+            map1.Add(2, "d");
+            map1.Add(2, "e");
+
+            map2.Add(2, "d");
+            map2.Add(1, "c");
+            map2.Add(1, "a");
+            map2.Add(2, "e");
+            map2.Add(1, "b");
+
+            //Assert
+            Assert.IsTrue(map1.Equals(map2), "GIVEN: Maps should be equal");
+            Assert.AreEqual(map1.GetHashCode(), map2.GetHashCode(), "Map hash codes should match when the maps have the same data");
+        }
+
+        [Test]
+        [Category("Unit")]
+        public void Given_OneLargeMap_When_HashCodeGenerated_Then_NoExceptionThrown()
+        {
+            //Assemble
+            IMultiValueMap<int, string> map = new MultiValueMapImpl<int, string>();
+
+            //Act
+            for (int index1 = 0; index1 < 20; index1++)
+            {
+                for (int index2 = 0; index2 < 20; index2++)
+                {
+                    map.Add(index1, index1 + ":" + index2);
+                }
+            }
+
+            //Assert
+            Assert.DoesNotThrow(() => map.GetHashCode(), "GetHashCode should not throw an exception");
+        }
     }
 }

--- a/CsharpExtrasTest/Extensions/ArrayExtensionTest.cs
+++ b/CsharpExtrasTest/Extensions/ArrayExtensionTest.cs
@@ -141,7 +141,7 @@ namespace CustomExtensions
                 sub = arr.SubArray(1, arr.Length - 1);
                 Assert.AreEqual(arr[1], sub[0],
                     "Expecting sub array to start at the right value");
-                Assert.AreEqual(arr[arr.Length - 2], sub[sub.Length - 1],
+                Assert.AreEqual(arr[^2], sub[^1],
                     "Expecting sub array to end at the right value");
             }
         }

--- a/CsharpExtrasTest/IO/DirectoryFacadeTest.cs
+++ b/CsharpExtrasTest/IO/DirectoryFacadeTest.cs
@@ -13,7 +13,7 @@ namespace IO
     [TestFixture]
     public class DirectoryFacadeTest
     {
-        IDirectoryFacade DirectoryFacade = new DirectoryFacadeImpl();
+        private readonly IDirectoryFacade _directoryFacade = new DirectoryFacadeImpl();
 
         [Test, Category("Unit")]
         public void TestGivenRootAndRelativeSubDirWhenCombineThenGetDifferenceThenResultEqualsRelativeSubDir()
@@ -22,7 +22,7 @@ namespace IO
             string[] relativeSubDirs = new string[] { "level1", "level2" };
             string relativeSubDir = Path.Combine(relativeSubDirs);
             string absoluteSubDir = Path.Combine(root, relativeSubDir);
-            string diff = DirectoryFacade.GetRelativeDifferenceBetweenPaths(root, absoluteSubDir);
+            string diff = _directoryFacade.GetRelativeDifferenceBetweenPaths(root, absoluteSubDir);
             Assert.AreEqual(relativeSubDir, diff);
         }
     }

--- a/CsharpExtrasTest/IO/DirectoryFacadeTest.cs
+++ b/CsharpExtrasTest/IO/DirectoryFacadeTest.cs
@@ -1,6 +1,5 @@
 ﻿using CsharpExtras.IO;
 using IO;
-using IO;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
## Description

Update project definition to treat all warnings as errors. If the compiler finds a warning it should not be ignored. Treating it as an error ensures this is the case.

## TODO

- [x] Update CHANGELOG
