### PR TITLE
Agile/fix/random string generator producing duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- RandomStringGenerator producing duplicate results when multiple instances used
 
 ### Changed
 - [BREAKING] Move the ArrayOrientation enum to a new namespace (#9)

--- a/CsharpExtras/Random/RandomStringGeneratorImpl.cs
+++ b/CsharpExtras/Random/RandomStringGeneratorImpl.cs
@@ -8,7 +8,7 @@ namespace CsharpExtras.RandomDataGen
 {
     class RandomStringGeneratorImpl : IRandomStringGenerator
     {
-        private readonly Random _random = new Random();
+        private static readonly Random _random = new Random();
         private const string NumberSet = "0123456789";
         private const string AlphaUpperCase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 

--- a/CsharpExtras/Random/RandomStringGeneratorImpl.cs
+++ b/CsharpExtras/Random/RandomStringGeneratorImpl.cs
@@ -8,7 +8,16 @@ namespace CsharpExtras.RandomDataGen
 {
     class RandomStringGeneratorImpl : IRandomStringGenerator
     {
-        private static readonly Random _random = new Random();
+        // Global Random instance that is shared across all threads - note that Random is NOT thread-safe
+        // Design inspired by this discussion: https://stackoverflow.com/questions/3049467/is-c-sharp-random-number-generator-thread-safe
+        private static readonly Random _globalRandom = new Random();
+
+        // Thread-specific instance of Random
+        // This Lazy property gets initialized the first time a given thread accesses this class
+        // The _globalRandom is used to generate a unique seed for each thread-specific instance
+        [ThreadStatic] private static Random? _threadRandom;
+        private static Random ThreadRandom => _threadRandom ??= BuildRandomInstanceForThread();
+
         private const string NumberSet = "0123456789";
         private const string AlphaUpperCase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
@@ -42,9 +51,19 @@ namespace CsharpExtras.RandomDataGen
             char[] stringChars = new char[length];
             for (int i = 0; i < length; i++)
             {
-                stringChars[i] = alphabet[_random.Next(alphabet.Length)];
+                stringChars[i] = alphabet[ThreadRandom.Next(alphabet.Length)];
             }
             return new string(stringChars);
         }
+
+        private static Random BuildRandomInstanceForThread()
+        {
+            lock (_globalRandom)
+            {
+                int seed = _globalRandom.Next();
+                return new Random(seed);
+            }
+        }
+
     }
 }


### PR DESCRIPTION
## Description

Update the `RandomStringGenerator` class to use a static `Random` variable to ensure that when multiple instances of this class are created, they do not all use the same initial seed (based on system time). By using a static instance, the random generator is shared and will always use a single seed.

This issue has been observed on a project that uses this library, but was not reproduceable as a test in this project.

## TODO

- [x] Update CHANGELOG
