### PR TITLE
Feature/90 disambiguate first index of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added functions to convert arrays to dictionaries (#60)
 - Added functions to find the last used row/column in 2D arrays (#75)
 - Added functions to find index tuple of a value inside a 2D array (#88)
+- Refactored various indexing functions on the IEnumerable extension and the OneBasedArray class to disambiguate between zero-based and one-based indexing (#90)
 
 ### Added
 - Support for writing a 1D one-based array to a 2D one-based array (#9)

--- a/CsharpExtras/Enumerable/OneBased/IOneBasedArray.cs
+++ b/CsharpExtras/Enumerable/OneBased/IOneBasedArray.cs
@@ -14,6 +14,7 @@ namespace CsharpExtras.Enumerable.OneBased
         int Length { get; }
 
         int FirstIndexOf(Func<TVal, bool> matchFunction);
+        int FirstIndexOf(TVal val);
         void PairAndExecute<TOther>(IOneBasedArray<TOther> other, Action<TVal, TOther> pairProcessor);
         void Resize(int newSize);
 
@@ -30,7 +31,6 @@ namespace CsharpExtras.Enumerable.OneBased
         /// If there are any duplicate values in this array, then an exception is thrown.
         /// </summary>
         IDictionary<TVal, TOther> ZipToDictionary<TOther>(IOneBasedArray<TOther> other);
-        
         ISetValuedDictionary<TVal, TOther> ZipToSetDictionary<TOther>(IOneBasedArray<TOther> other);
 
         IOneBasedArray<TResult> ZipArray<TOther1, TOther2, TResult>(Func<TVal, TOther1, TOther2, TResult> zipper, IOneBasedArray<TOther1> other1, IOneBasedArray<TOther2> other2);

--- a/CsharpExtras/Enumerable/OneBased/OneBasedArray.cs
+++ b/CsharpExtras/Enumerable/OneBased/OneBasedArray.cs
@@ -65,11 +65,7 @@ namespace CsharpExtras.Enumerable.OneBased
 
         public int FirstIndexOf(TVal val) => this.FirstIndexOfOneBased(val);
 
-        public int FirstIndexOf(Func<TVal, bool> matchFunction)
-        {
-            return -1;
-            //STUBBED OUT FOR RED-GREEN TESTING: return this.FirstIndexOf(matchFunction, 1);
-        }
+        public int FirstIndexOf(Func<TVal, bool> matchFunction) => this.FirstIndexOf(matchFunction, 1);
 
         public void Resize(int newSize)
         {

--- a/CsharpExtras/Enumerable/OneBased/OneBasedArray.cs
+++ b/CsharpExtras/Enumerable/OneBased/OneBasedArray.cs
@@ -63,9 +63,12 @@ namespace CsharpExtras.Enumerable.OneBased
             return FindFirstOccurrenceOfSet(set, 1, Length+1);
         }
 
+        public int FirstIndexOf(TVal val) => this.FirstIndexOfOneBased(val);
+
         public int FirstIndexOf(Func<TVal, bool> matchFunction)
         {
-            return ZeroBasedEquivalent.FirstIndexOf(matchFunction) + 1;
+            return -1;
+            //STUBBED OUT FOR RED-GREEN TESTING: return this.FirstIndexOf(matchFunction, 1);
         }
 
         public void Resize(int newSize)

--- a/CsharpExtras/Extensions/IEnumerableExtension.cs
+++ b/CsharpExtras/Extensions/IEnumerableExtension.cs
@@ -12,10 +12,14 @@ namespace CsharpExtras.Extensions
         public static IDictionary<int, U> IndexZeroBased<U>(this IEnumerable<U> values) => Index(values, 0);
 
         public static IDictionary<int, U> Index<U>(this IEnumerable<U> values, int startIndex)
-        {
-            return new Dictionary<int, U>();
-            //return Index(values, startIndex, 1);
-        }
+            => Index(values, startIndex, 1);
+
+        /// <summary>
+        /// Indexes this enumerable into a dictionary whose keys are the indices of elements in the enumerable.
+        /// </summary>
+        /// <param name="startIndex">The index to assign to the first index of the enumerable</param>
+        /// <param name="step">The difference between successive indices in the enumerable</param>
+        /// <returns></returns>
         public static IDictionary<int, U> Index<U>(this IEnumerable<U> values, int startIndex, int step)
         {
             IDictionary<int, U> dict = new Dictionary<int, U>();
@@ -49,17 +53,19 @@ namespace CsharpExtras.Extensions
         /// <summary>
         /// Find the first row that matches the provided function. If none found, return -1
         /// </summary>
+        /// <param name="equalityProvider">The function will stop at the first match of this</param>
+        /// <param name="startIndex">The index to assign to the first element in the enumerable</param>
+        /// <returns></returns>
         public static int FirstIndexOf<T>(this IEnumerable<T> values, Func<T, bool> equalityProvider, int startIndex)
         {
-            return -1; //STUBBED FOR NOW TO RED/GREEEN TEST
-            /*for (int i = 0; i < values.Count(); i++)
+            for (int i = 0; i < values.Count(); i++)
             {
                 if (equalityProvider.Invoke(values.ElementAt(i)))
                 {
-                    return i;
+                    return startIndex + i;
                 }
             }
-            return -1;*/
+            return -1;
         }
 
         //non-mvp: sliceRow should be consistent with Slice column (can we write a common function to reduce repetition?)

--- a/CsharpExtras/Extensions/IEnumerableExtension.cs
+++ b/CsharpExtras/Extensions/IEnumerableExtension.cs
@@ -8,13 +8,13 @@ namespace CsharpExtras.Extensions
 {
     public static class IEnumerableExtension
     {
-        public static IDictionary<int, U> Index<U>(this IEnumerable<U> values)
-        {
-            return Index(values, 1);
-        }
+        public static IDictionary<int, U> IndexOneBased<U>(this IEnumerable<U> values) => Index(values, 1);
+        public static IDictionary<int, U> IndexZeroBased<U>(this IEnumerable<U> values) => Index(values, 0);
+
         public static IDictionary<int, U> Index<U>(this IEnumerable<U> values, int startIndex)
         {
-            return Index(values, startIndex, 1);
+            return new Dictionary<int, U>();
+            //return Index(values, startIndex, 1);
         }
         public static IDictionary<int, U> Index<U>(this IEnumerable<U> values, int startIndex, int step)
         {
@@ -36,24 +36,30 @@ namespace CsharpExtras.Extensions
             }
         }
 
-        public static int FirstIndexOf<T>(this IEnumerable<T> values, T value)
+        public static int FirstIndexOfOneBased<T>(this IEnumerable<T> values, T value) =>
+            values.FirstIndexOf(value, 1);
+        public static int FirstIndexOfZeroBased<T>(this IEnumerable<T> values, T value) =>
+            values.FirstIndexOf(value, 0);
+
+        public static int FirstIndexOf<T>(this IEnumerable<T> values, T value, int startIndex)
         {            
-            return values.FirstIndexOf(v => v != null && v.Equals(value));
+            return values.FirstIndexOf(v => v != null && v.Equals(value), startIndex);
         }
 
         /// <summary>
         /// Find the first row that matches the provided function. If none found, return -1
         /// </summary>
-        public static int FirstIndexOf<T>(this IEnumerable<T> values, Func<T, bool> equalityProvider)
+        public static int FirstIndexOf<T>(this IEnumerable<T> values, Func<T, bool> equalityProvider, int startIndex)
         {
-            for (int i = 0; i < values.Count(); i++)
+            return -1; //STUBBED FOR NOW TO RED/GREEEN TEST
+            /*for (int i = 0; i < values.Count(); i++)
             {
                 if (equalityProvider.Invoke(values.ElementAt(i)))
                 {
                     return i;
                 }
             }
-            return -1;
+            return -1;*/
         }
 
         //non-mvp: sliceRow should be consistent with Slice column (can we write a common function to reduce repetition?)

--- a/CsharpExtras/Extensions/IEnumerableExtension.cs
+++ b/CsharpExtras/Extensions/IEnumerableExtension.cs
@@ -11,19 +11,19 @@ namespace CsharpExtras.Extensions
         public static IDictionary<int, U> IndexOneBased<U>(this IEnumerable<U> values) => Index(values, 1);
         public static IDictionary<int, U> IndexZeroBased<U>(this IEnumerable<U> values) => Index(values, 0);
 
-        public static IDictionary<int, U> Index<U>(this IEnumerable<U> values, int startIndex)
-            => Index(values, startIndex, 1);
+        public static IDictionary<int, U> Index<U>(this IEnumerable<U> values, int baseIndex)
+            => Index(values, baseIndex, 1);
 
         /// <summary>
         /// Indexes this enumerable into a dictionary whose keys are the indices of elements in the enumerable.
         /// </summary>
-        /// <param name="startIndex">The index to assign to the first index of the enumerable</param>
+        /// <param name="baseIndex">The index to assign to the first index of the enumerable</param>
         /// <param name="step">The difference between successive indices in the enumerable</param>
         /// <returns></returns>
-        public static IDictionary<int, U> Index<U>(this IEnumerable<U> values, int startIndex, int step)
+        public static IDictionary<int, U> Index<U>(this IEnumerable<U> values, int baseIndex, int step)
         {
             IDictionary<int, U> dict = new Dictionary<int, U>();
-            int currIndex = startIndex;
+            int currIndex = baseIndex;
             foreach (U u in values)
             {
                 dict.Add(currIndex, u);
@@ -45,24 +45,24 @@ namespace CsharpExtras.Extensions
         public static int FirstIndexOfZeroBased<T>(this IEnumerable<T> values, T value) =>
             values.FirstIndexOf(value, 0);
 
-        public static int FirstIndexOf<T>(this IEnumerable<T> values, T value, int startIndex)
+        public static int FirstIndexOf<T>(this IEnumerable<T> values, T value, int baseIndex)
         {            
-            return values.FirstIndexOf(v => v != null && v.Equals(value), startIndex);
+            return values.FirstIndexOf(v => v != null && v.Equals(value), baseIndex);
         }
 
         /// <summary>
         /// Find the first row that matches the provided function. If none found, return -1
         /// </summary>
         /// <param name="equalityProvider">The function will stop at the first match of this</param>
-        /// <param name="startIndex">The index to assign to the first element in the enumerable</param>
+        /// <param name="baseIndex">The index to assign to the first element in the enumerable</param>
         /// <returns></returns>
-        public static int FirstIndexOf<T>(this IEnumerable<T> values, Func<T, bool> equalityProvider, int startIndex)
+        public static int FirstIndexOf<T>(this IEnumerable<T> values, Func<T, bool> equalityProvider, int baseIndex)
         {
             for (int i = 0; i < values.Count(); i++)
             {
                 if (equalityProvider.Invoke(values.ElementAt(i)))
                 {
-                    return startIndex + i;
+                    return baseIndex + i;
                 }
             }
             return -1;

--- a/CsharpExtrasTest/Enumerable/OneBased/OneBasedArrayTest.cs
+++ b/CsharpExtrasTest/Enumerable/OneBased/OneBasedArrayTest.cs
@@ -31,7 +31,21 @@ namespace OneBased
             //Assert
             Assert.AreEqual(4, firstIndex);
         }
-        
+
+        [Test]
+        public void Given_OneBasedArray_WhenGetFirstIndexOfNonLambda_Then_OneBasedIndexReturned()
+        {
+            //Arrange
+            byte[] zeroBased = new byte[] { 0, 2, 4, 3, 6, 10 };
+            IOneBasedArray<byte> arr = new OneBasedArrayImpl<byte>(zeroBased);
+
+            //Act
+            int firstIndex = arr.FirstIndexOf<byte>(3);
+
+            //Assert
+            Assert.AreEqual(4, firstIndex);
+        }
+
         [Test]
         public void GivenOneBasedArrayWhenMapAppliedThenResultIsArrayOfMappedValues()
         {

--- a/CsharpExtrasTest/Enumerable/OneBased/OneBasedArrayTest.cs
+++ b/CsharpExtrasTest/Enumerable/OneBased/OneBasedArrayTest.cs
@@ -33,14 +33,28 @@ namespace OneBased
         }
 
         [Test]
-        public void Given_OneBasedArray_WhenGetFirstIndexOfNonLambda_Then_OneBasedIndexReturned()
+        public void Given_OneBasedArray_WhenGetOneBasedFirstIndexOfFalseMatcher_Then_MinusOne()
         {
             //Arrange
             byte[] zeroBased = new byte[] { 0, 2, 4, 3, 6, 10 };
             IOneBasedArray<byte> arr = new OneBasedArrayImpl<byte>(zeroBased);
 
             //Act
-            int firstIndex = arr.FirstIndexOf<byte>(3);
+            int firstIndex = arr.FirstIndexOf(b => false);
+
+            //Assert
+            Assert.AreEqual(-1, firstIndex);
+        }
+
+        [Test]
+        public void Given_OneBasedArray_WhenGetFirstIndexOfNonLambdaMatchingElement_Then_OneBasedIndexReturned()
+        {
+            //Arrange
+            byte[] zeroBased = new byte[] { 0, 2, 4, 3, 6, 10 };
+            IOneBasedArray<byte> arr = new OneBasedArrayImpl<byte>(zeroBased);
+
+            //Act
+            int firstIndex = arr.FirstIndexOf(3);
 
             //Assert
             Assert.AreEqual(4, firstIndex);

--- a/CsharpExtrasTest/Extensions/IEnumerableExtensionTest.cs
+++ b/CsharpExtrasTest/Extensions/IEnumerableExtensionTest.cs
@@ -5,45 +5,127 @@ using System.Collections.Generic;
 namespace CustomExtensions
 {
     [TestFixture]
-        public class IEnumerableTest
+    public class IEnumerableTest
+    {
+        private const string Zero = "Zero";
+        private const string One = "One";
+        private const string Two = "Two";
+        private const string Three = "Three";
+
+        [Test, Category("Unit")]
+        [TestCaseSource("ValidIndexingData")]
+        public void GivenEnumerableWhenIndexedThenResultantDictionaryIsAsExpected(int startIndex, int step, int[] expectedKeysInOrder)
         {
-            private const string Zero = "Zero";
-            private const string One = "One";
-            private const string Two = "Two";
-
-            [Test, Category("Unit")]
-            [TestCaseSource("ValidIndexingData")]
-            public void GivenEnumerableWhenIndexedThenResultantDictionaryIsAsExpected(int startIndex, int step, int[] expectedKeysInOrder)
-            {
-                //Arrange
-                string[] mockData = new string[] { Zero, One, Two };
-                IDictionary<int, string> indexedDict = mockData.Index(startIndex, step);
+            //Arrange
+            string[] mockData = new string[] { Zero, One, Two };
+            IDictionary<int, string> indexedDict = mockData.Index(startIndex, step);
                 
-                //Act
-                ICollection<int> actualKeys = indexedDict.Keys;
+            //Act
+            ICollection<int> actualKeys = indexedDict.Keys;
                 
-                //Assert
-                Assert.AreEqual(expectedKeysInOrder, actualKeys, "Keys in resultant dictionary differ from those expected.");
-                for(int originalIndex = 0; originalIndex < mockData.Length; originalIndex++)
-                {
-                    int keyInIndexedDict = expectedKeysInOrder[originalIndex];
-                    string expectedData = mockData[originalIndex];
-                    string actualData = indexedDict[keyInIndexedDict];
-                    Assert.AreEqual(expectedData, actualData, string.Format(
-                        "Indexed dictionary data does not match original enumerable data. Index in original enumerable: {0}. Index in indexed dictionary: {1}",
-                        originalIndex, keyInIndexedDict));
-                }
-            }
-
-            public static IEnumerable<object[]> ValidIndexingData()
+            //Assert
+            Assert.AreEqual(expectedKeysInOrder, actualKeys, "Keys in resultant dictionary differ from those expected.");
+            for(int originalIndex = 0; originalIndex < mockData.Length; originalIndex++)
             {
-                return new List<object[]>()
-                {
-                    new object[] { 0, 2, new int[] { 0, 2, 4} },
-                    new object[] { 0, -3, new int[] { 0, -3, -6} },
-                    new object[] { 6, 5, new int[] { 6, 11, 16} },
-                    new object[] { 6, -7, new int[] { 6, -1, -8} },
-                };
+                int keyInIndexedDict = expectedKeysInOrder[originalIndex];
+                string expectedData = mockData[originalIndex];
+                string actualData = indexedDict[keyInIndexedDict];
+                Assert.AreEqual(expectedData, actualData, string.Format(
+                    "Indexed dictionary data does not match original enumerable data. Index in original enumerable: {0}. Index in indexed dictionary: {1}",
+                    originalIndex, keyInIndexedDict));
             }
         }
+
+        [Test, Category("Unit")]
+        public void GIVEN_Enumerable_WHEN_IndexZeroBased_THEN_DictionaryWithOneBasedIndicesReturned()
+        {
+            //Assemble
+            string[] mockData = new string[] { Zero, One, Two };
+
+            //Act
+            IDictionary<int, string> dict = mockData.IndexZeroBased();
+
+            //Assert
+            Assert.AreEqual(new Dictionary<int, string> {[0] = Zero, [1] = One, [2] = Two}, dict);
+        }
+
+        [Test, Category("Unit")]
+        public void GIVEN_Enumerable_WHEN_IndexOneBased_THEN_DictionaryWithOneBasedIndicesReturned()
+        {
+            //Assemble
+            string[] mockData = new string[] { One, Two, Three };
+
+            //Act
+            IDictionary<int, string> dict = mockData.IndexOneBased();
+
+            //Assert
+            Assert.AreEqual(new Dictionary<int, string> { [1] = One, [2] = Two, [3] = Three }, dict);
+        }
+
+        [Test, Category("Unit")]
+        public void GIVEN_Enumerable_WHEN_OneBasedFirstIndexOfMatchingElement_THEN_OneBasedIndexReturned()
+        {
+            //Assemble
+            string[] mockData = new string[] { One, Two, Three };
+
+            //Act
+            int firstIndex = mockData.FirstIndexOfOneBased(Two);
+
+            //Assert
+            Assert.AreEqual(2, firstIndex);
+        }
+
+        [Test, Category("Unit")]
+        public void GIVEN_Enumerable_WHEN_OneBasedFirstIndexOfNonMatchingElement_THEN_MinusOneReturned()
+        {
+            //Assemble
+            string[] mockData = new string[] { One, Two, Three };
+
+            //Act
+            int firstIndex = mockData.FirstIndexOfOneBased("Non-existent-data");
+
+            //Assert
+            Assert.AreEqual(-1, firstIndex);
+        }
+
+        [Test, Category("Unit")]
+        public void GIVEN_Enumerable_WHEN_ZeroBasedFirstIndexOfMatchingElement_THEN_ZeroBasedIndexReturned()
+        {
+            //Assemble
+            string[] mockData = new string[] { Zero, One, Two };
+
+            //Act
+            int firstIndex = mockData.FirstIndexOfZeroBased(One);
+
+            //Assert
+            Assert.AreEqual(1, firstIndex);
+        }
+
+        [Test, Category("Unit")]
+        public void GIVEN_Enumerable_WHEN_ZeroBasedFirstIndexOfNonMatchingElement_THEN_MinusZeroReturned()
+        {
+            //Assemble
+            string[] mockData = new string[] { Zero, One, Two };
+
+            //Act
+            int firstIndex = mockData.FirstIndexOfZeroBased("Non-existent-data");
+
+            //Assert
+            Assert.AreEqual(-1, firstIndex);
+        }
+
+
+        #region Providers
+        public static IEnumerable<object[]> ValidIndexingData()
+        {
+            return new List<object[]>()
+            {
+                new object[] { 0, 2, new int[] { 0, 2, 4} },
+                new object[] { 0, -3, new int[] { 0, -3, -6} },
+                new object[] { 6, 5, new int[] { 6, 11, 16} },
+                new object[] { 6, -7, new int[] { 6, -1, -8} },
+            };
+        }
+    #endregion
+}
 }


### PR DESCRIPTION
## Description

Refactored various indexing functions on the IEnumerable extension and the OneBasedArray class to disambiguate between zero-based and one-based indexing.