### PR TITLE
Feature/92 map values include key data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added functions to find the last used row/column in 2D arrays (#75)
 - Added functions to find index tuple of a value inside a 2D array (#88)
 - Refactored various indexing functions on the IEnumerable extension and the OneBasedArray class to disambiguate between zero-based and one-based indexing (#90)
+- Added dictionary extension method for mapping values including the key as input data to the mapper function (#92)
 
 ### Added
 - Support for writing a 1D one-based array to a 2D one-based array (#9)

--- a/CsharpExtras/Extensions/DictionaryExtension.cs
+++ b/CsharpExtras/Extensions/DictionaryExtension.cs
@@ -33,15 +33,8 @@ namespace CsharpExtras.Extensions
         /// <returns>A new dictionary whose keys are the same as the source dictionary and whose values are the 
         /// result of applying the mapper function over the values in the source dictionary.</returns>
         public static IDictionary<TKey, TMapped> MapValues<TKey, TValue, TMapped>
-            (this IDictionary<TKey, TValue> dictionary, Func<TValue, TMapped> mapper)
-        {
-            Dictionary<TKey, TMapped> dictToReturn = new Dictionary<TKey, TMapped>();
-            foreach (TKey k in dictionary.Keys)
-            {
-                dictToReturn.Add(k, mapper(dictionary[k]));
-            }
-            return dictToReturn;
-        }
+            (this IDictionary<TKey, TValue> dictionary, Func<TValue, TMapped> mapper) =>
+            dictionary.MapValues((k, v) => mapper(v));
 
         /// <summary>
         /// Maps the values in the given dictionary using the given mapper function
@@ -57,6 +50,11 @@ namespace CsharpExtras.Extensions
             (this IDictionary<TKey, TValue> dictionary, Func<TKey, TValue, TMapped> mapper)
         {
             Dictionary<TKey, TMapped> dictToReturn = new Dictionary<TKey, TMapped>();
+            foreach (KeyValuePair<TKey, TValue> pair in dictionary)
+            {
+                TKey key = pair.Key;
+                dictToReturn.Add(key, mapper(key, dictionary[key]));
+            }
             return dictToReturn;
         }
 

--- a/CsharpExtras/Extensions/DictionaryExtension.cs
+++ b/CsharpExtras/Extensions/DictionaryExtension.cs
@@ -22,13 +22,41 @@ namespace CsharpExtras.Extensions
                  : defaultValueProvider();
         }
 
-        public static IDictionary<TKey, TMapped> MapValues<TKey, TValue, TMapped>(this IDictionary<TKey, TValue> dictionary, Func<TValue, TMapped> mapper)
+        /// <summary>
+        /// Maps the values in the given dictionary using the given mapper function.
+        /// </summary>
+        /// <typeparam name="TKey">Type of keys in the dictionary</typeparam>
+        /// <typeparam name="TValue">Type of values in the source dictionary</typeparam>
+        /// <typeparam name="TMapped">Type of values in the target dictionary</typeparam>
+        /// <param name="dictionary">The source dictionary</param>
+        /// <param name="mapper">A function which, given a value of the source type, returns a value of the target type</param>
+        /// <returns>A new dictionary whose keys are the same as the source dictionary and whose values are the 
+        /// result of applying the mapper function over the values in the source dictionary.</returns>
+        public static IDictionary<TKey, TMapped> MapValues<TKey, TValue, TMapped>
+            (this IDictionary<TKey, TValue> dictionary, Func<TValue, TMapped> mapper)
         {
             Dictionary<TKey, TMapped> dictToReturn = new Dictionary<TKey, TMapped>();
             foreach (TKey k in dictionary.Keys)
             {
                 dictToReturn.Add(k, mapper(dictionary[k]));
             }
+            return dictToReturn;
+        }
+
+        /// <summary>
+        /// Maps the values in the given dictionary using the given mapper function
+        /// </summary>
+        /// <typeparam name="TKey">Type of keys in the dictionary</typeparam>
+        /// <typeparam name="TValue">Type of values in the source dictionary</typeparam>
+        /// <typeparam name="TMapped">Type of values in the target dictionary</typeparam>
+        /// <param name="dictionary">The source dictionary</param>
+        /// <param name="mapper">A function which, given a key/value pair from the source dictionary, returns a value of the target type</param>
+        /// <returns>A new dictionary whose keys are the same as the source dictionary and whose values are the 
+        /// result of applying the mapper function over the key/value pairs in the source dictionary.</returns>
+        public static IDictionary<TKey, TMapped> MapValues<TKey, TValue, TMapped>
+            (this IDictionary<TKey, TValue> dictionary, Func<TKey, TValue, TMapped> mapper)
+        {
+            Dictionary<TKey, TMapped> dictToReturn = new Dictionary<TKey, TMapped>();
             return dictToReturn;
         }
 

--- a/CsharpExtrasTest/Extensions/DictionaryTest.cs
+++ b/CsharpExtrasTest/Extensions/DictionaryTest.cs
@@ -87,6 +87,24 @@ namespace CustomExtensions
 
         [Test]
         [Category("Unit")]
+        public void GIVEN_Dictionary_WHEN_MapValuesWithKeyValueMapper_THEN_ExpectedDictionaryReturned()
+        {
+            //Assemble
+            IDictionary<int, string> mockDict = new Dictionary<int, string>()
+                { [1] = "1", [2] = "2", [3] = "3" };
+            Func<int, string, (int, string)> mapper = (i, s) => (i, s);
+
+            //Act
+            IDictionary<int, (int, string)> actualDict = mockDict.MapValues(mapper);
+
+            //Assert
+            IDictionary<int, (int, string)> expectedDict = new Dictionary<int, (int, string)>()
+            { [1] = (1, "1"), [2] = (2, "2"), [3] = (3, "3") };
+            Assert.AreEqual(expectedDict, actualDict);
+        }
+
+        [Test]
+        [Category("Unit")]
         public void GivenDictionaryWhenAddWithValueDerivedFromKeyCalledThenCorrectItemAddedToDictionary()
         {
             //Arrange


### PR DESCRIPTION
## Description

Closes #92. Added dictionary extension method for mapping values including the key as input data to the mapper function.
