### PR TITLE
Feature/update build and release strategy

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -21,14 +21,16 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.101
+    - name: Update version
+      run: cd BuildTools && chmod +x *.sh && ./UpdateVersion.sh
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --configuration Release --no-restore --verbosity normal
     - name: Test
-      run: dotnet test --no-restore --verbosity normal
+      run: dotnet test --configuration Release --no-restore --no-build --verbosity normal
     - name: Package
-      run: cd BuildTools && chmod +x *.sh && ./Build.sh
+      run: dotnet pack CsharpExtras.csproj --configuration Release --no-restore --no-build
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -3,6 +3,8 @@ name: .NET Core
 on:
   push:
     branches: [ develop ]
+    tags:
+      - '*'
   pull_request:
     branches: [ develop ]
 

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Test
       run: dotnet test --configuration Release --no-restore --no-build --verbosity normal
     - name: Package
-      run: dotnet pack CsharpExtras.csproj --configuration Release --no-restore --no-build
+      run: cd CsharpExtras && dotnet pack CsharpExtras.csproj --configuration Release --no-restore --no-build
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:

--- a/BuildTools/Build.sh
+++ b/BuildTools/Build.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-./UpdateVersion.sh
-
-cd ../CsharpExtras
-dotnet build --configuration Release
-dotnet pack CsharpExtras.csproj --configuration Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added functions to find index tuple of a value inside a 2D array (#88)
 - Refactored various indexing functions on the IEnumerable extension and the OneBasedArray class to disambiguate between zero-based and one-based indexing (#90)
 - Added dictionary extension method for mapping values including the key as input data to the mapper function (#92)
-- [BREAKING] Refactored File and Directory Facades & decorators. Updated File creation to throw exception if directory already exists. (#92)
+- [BREAKING] Refactored File and Directory Facades & decorators. Updated File creation to throw exception if directory already exists. (#94)
+- [BREAKING] Refactored how the GitHub build works to support a release strategy with pre-releases and semantic versioning. No code changes. (#34)
 
 ### Added
 - Support for writing a 1D one-based array to a 2D one-based array (#9)


### PR DESCRIPTION
## Description

Updated the build workflow:

1. The YML file now controls the build in a CI flow, without repetition of tasks (hopefully). Prior to this it looks like there was repetition because of subsequent build tasks including previous ones e.g. dotnet build includes a restore. Looks like there was also repetition due to the fact that the build.sh file was being called to do the build & pack, which seemed to repeat the build that the YML file just did.
2. The YML file is now set up to build on new tags. This will allow for the new release strategy: a new build should be triggered when a new release & tag are created.
3. The build.sh file was removed, as it is no longer used. The YML is now the controller of the build logic.
