### PR TITLE
Fixed Sparse Array Default Write Persist Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a shift operator for sparse arrays (#122)
 - Added a pre-access wrapper, which wraps an object and ensures an action is run before any access to that object (#131)
 - Added zip methods for sparse array and sparse array 2D (#132)
+- Fixed bug: default values were not overwriting non-defaults for sparse arrays (#134)
 
 ### Added
 - Support for writing a 1D one-based array to a 2D one-based array (#9)

--- a/CsharpExtras/Map/Sparse/ISparseArray.cs
+++ b/CsharpExtras/Map/Sparse/ISparseArray.cs
@@ -20,6 +20,7 @@ namespace CsharpExtras.Map.Sparse
     {
         /// <summary>
         /// Gets/sets the underlying value at the given sequence of coordinates
+        /// Note: if a value is set to the default value, then it is no longer considered used
         /// </summary>
         /// <param name="coordinates">A sequence of coordinates which must match the dimension of this array</param>
         /// <returns>The last value that was written to those coordinates, or else the default if no value was written</returns>

--- a/CsharpExtras/Map/Sparse/SparseArrayImpl.cs
+++ b/CsharpExtras/Map/Sparse/SparseArrayImpl.cs
@@ -41,6 +41,7 @@ namespace CsharpExtras.Map.Sparse
             ValidIndex[] validatedCoordinates = GetValidateCoordinated(coordinates);
             if (EqualityComparer<TVal>.Default.Equals(value, DefaultValue))
             {
+                _backingDictionary.Remove(validatedCoordinates);
                 return;
             }
             if (!_backingDictionary.Update(value, validatedCoordinates))

--- a/CsharpExtras/Map/Sparse/TwoDimensional/ISparseArray2D.cs
+++ b/CsharpExtras/Map/Sparse/TwoDimensional/ISparseArray2D.cs
@@ -12,6 +12,7 @@ namespace CsharpExtras.Map.Sparse.TwoDimensional
     {
         /// <summary>
         /// Get or set the value at the given row, column coordinates
+        /// Note: if a value is set to the default value, then it is no longer considered used
         /// </summary>
         TVal this[int row, int column] { get; set; }
 
@@ -68,6 +69,7 @@ namespace CsharpExtras.Map.Sparse.TwoDimensional
         /// <summary>
         /// Sets an area to the given values at the given coordinates.
         /// If coordinates within the area are invalid, throws an exception.
+        /// Note: If a value is set to the default value, then it is no longer considered used
         /// </summary>
         /// <param name="area">The are to write to this array</param>
         /// <param name="leftmostRow">The row coordinate of the top-left corner of the rectangle to which to write</param>

--- a/CsharpExtrasTest/Map/Sparse/SparseArrayTest.cs
+++ b/CsharpExtrasTest/Map/Sparse/SparseArrayTest.cs
@@ -17,6 +17,51 @@ namespace CsharpExtrasTest.Map.Sparse
     {
         private ICsharpExtrasApi Api { get; } = new CsharpExtrasApi();
 
+        [Test]
+        public void GIVEN_SparseArray_WHEN_SetToDefault_THEN_IsUsedIsFalse()
+        {
+            //Arrange
+            ISparseArray<string> array = Api.NewSparseArrayBuilder((PositiveInteger)3, "").Build();
+            array[1, 2, 3] = "Initial Non-default value";
+            Assert.IsTrue(array.IsUsed(1, 2, 3),
+                "GIVEN: Coordinates should be used initially as a non-default value exists there");
+
+            //Act
+            array[1, 2, 3] = "";
+
+            //Assert
+            Assert.IsFalse(array.IsUsed(1, 2, 3));
+        }
+
+        [Test]
+        public void GIVEN_SingletonArray_WHEN_SetUniqueValueToDefault_THEN_CountIsZero()
+        {
+            //Arrange
+            ISparseArray<string> array = Api.NewSparseArrayBuilder((PositiveInteger)3, "").Build();
+            array[1, 2, 3] = "Initial Non-default value";
+            Assert.AreEqual(1, (int) array.UsedValuesCount, "GIVEN: Singleton array count should be 1");
+
+            //Act
+            array[1, 2, 3] = "";
+
+            //Assert
+            Assert.AreEqual(0, (int) array.UsedValuesCount, "After writing default value, used count should be zero");
+        }
+
+        [Test]
+        public void GIVEN_SparseArray_WHEN_SetToDefault_THEN_GetReturnsDefault()
+        {
+            //Arrange
+            ISparseArray<string> array = Api.NewSparseArrayBuilder((PositiveInteger)3, "").Build();
+            array[1, 2, 3] = "Initial Non-default value";
+
+            //Act
+            array[1, 2, 3] = "";
+
+            //Assert
+            Assert.AreEqual("", array[1, 2, 3]);
+        }
+
         [Test, TestCase(false, 0, 0, 0), TestCase(true, 3, 4, 6), TestCase(true, 1, 1, 1)]
         public void GIVEN_FilledArray_WHEN_IsUsedEnum_THEN_ExpectedResult(bool expected, params int[] coordinates)
         {


### PR DESCRIPTION
## Description

Added 3 tests to confirm writing default behaves as expected. Fixed logic by calling remove on the backing dictionary whenever a default is written.

## TODO

 - [x] Closes #134 
 - [x] Tests added
 - [x] Update CHANGELOG
